### PR TITLE
added http response object in return for all func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/onmetahq/meta-http
 
 go 1.17
 
-require (
-	github.com/go-kit/log v0.2.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
-)
+require github.com/go-kit/log v0.2.0
+
+require github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/pkg/meta_http/client.go
+++ b/pkg/meta_http/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/onmetahq/meta-http/pkg/models"
 	"github.com/onmetahq/meta-http/pkg/utils"
 )
 
@@ -228,13 +229,13 @@ type loggingRoundTripper struct {
 
 func (l loggingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	presentTime := time.Now()
-	level.Debug(l.logger).Log("msg", "Initiating call", "path", r.URL.Path, "host", r.URL.Host, string(RequestID), r.Header.Get(string(RequestID)))
+	level.Debug(l.logger).Log("msg", "Initiating call", "path", r.URL.Path, "host", r.URL.Host, string(models.RequestID), r.Header.Get(string(models.RequestID)))
 	res, err := l.next.RoundTrip(r)
 	if err != nil {
-		level.Debug(l.logger).Log("msg", "Call Ended", "path", r.URL.Path, "host", r.URL.Host, "duration", time.Since(presentTime).Milliseconds(), "error", err.Error(), string(RequestID), r.Header.Get(string(RequestID)))
+		level.Debug(l.logger).Log("msg", "Call Ended", "path", r.URL.Path, "host", r.URL.Host, "duration", time.Since(presentTime).Milliseconds(), "error", err.Error(), string(models.RequestID), r.Header.Get(string(models.RequestID)))
 		return nil, err
 	}
-	level.Debug(l.logger).Log("msg", "Call Ended", "path", r.URL.Path, "host", r.URL.Host, "duration", time.Since(presentTime).Milliseconds(), "status", res.StatusCode, string(RequestID), r.Header.Get(string(RequestID)))
+	level.Debug(l.logger).Log("msg", "Call Ended", "path", r.URL.Path, "host", r.URL.Host, "duration", time.Since(presentTime).Milliseconds(), "status", res.StatusCode, string(models.RequestID), r.Header.Get(string(models.RequestID)))
 	return res, err
 }
 

--- a/pkg/meta_http/client_test.go
+++ b/pkg/meta_http/client_test.go
@@ -41,7 +41,9 @@ func TestMetaHTTPClient(t *testing.T) {
 	if res.Goodbye != "World" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp.Status)
+	if resp != nil {
+		t.Log(resp.StatusCode)
+	}
 }
 
 func TestTimeoutScenario(t *testing.T) {
@@ -68,7 +70,9 @@ func TestTimeoutScenario(t *testing.T) {
 	if err == nil {
 		t.Error("Supposed to fail with error")
 	}
-	t.Log(resp.Status)
+	if resp != nil {
+		t.Log(resp.Status)
+	}
 }
 
 func TestContextHeaders(t *testing.T) {
@@ -103,7 +107,9 @@ func TestContextHeaders(t *testing.T) {
 	if res[string(models.UserID)] != "userId" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp.Status)
+	if resp != nil {
+		t.Log(resp.StatusCode)
+	}
 }
 
 func TestHeadersContext(t *testing.T) {
@@ -141,7 +147,9 @@ func TestHeadersContext(t *testing.T) {
 	if res["data"] != "abcd" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp.Status)
+	if resp != nil {
+		t.Log(resp.Status)
+	}
 	res = map[string]string{}
 	resp, err = metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
 	if err != nil {
@@ -150,5 +158,7 @@ func TestHeadersContext(t *testing.T) {
 	if _, ok := res["data"]; ok {
 		t.Error("Data is not as expected")
 	}
-	t.Log(resp.Status)
+	if resp != nil {
+		t.Log(resp.Status)
+	}
 }

--- a/pkg/meta_http/client_test.go
+++ b/pkg/meta_http/client_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-kit/log"
 	metahttp "github.com/onmetahq/meta-http/pkg/meta_http"
+	"github.com/onmetahq/meta-http/pkg/models"
+	"github.com/onmetahq/meta-http/pkg/utils"
 )
 
 func TestMetaHTTPClient(t *testing.T) {
@@ -69,9 +71,9 @@ func TestTimeoutScenario(t *testing.T) {
 
 func TestContextHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		userId := req.Header.Get(string(metahttp.UserID))
+		userId := req.Header.Get(string(models.UserID))
 		res := map[string]string{
-			string(metahttp.UserID): userId,
+			string(models.UserID): userId,
 		}
 		bytes, _ := json.Marshal(res)
 		rw.Write(bytes)
@@ -89,14 +91,14 @@ func TestContextHeaders(t *testing.T) {
 	}
 	var res map[string]string
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, metahttp.UserID, "userId")
-	ctx = context.WithValue(ctx, metahttp.RequestID, "request-id")
+	ctx = context.WithValue(ctx, models.UserID, "userId")
+	ctx = context.WithValue(ctx, models.RequestID, "request-id")
 
 	err := metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if res[string(metahttp.UserID)] != "userId" {
+	if res[string(models.UserID)] != "userId" {
 		t.Error("Response body is not as expected")
 	}
 }
@@ -104,8 +106,8 @@ func TestContextHeaders(t *testing.T) {
 func TestHeadersContext(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		res := map[string]string{}
-		ctx := metahttp.FetchContextFromHeaders(context.Background(), req)
-		if userId, ok := ctx.Value(metahttp.UserID).(string); ok {
+		ctx := utils.FetchContextFromHeaders(context.Background(), req)
+		if userId, ok := ctx.Value(models.UserID).(string); ok {
 			res["data"] = userId
 		}
 		bytes, _ := json.Marshal(res)
@@ -126,7 +128,7 @@ func TestHeadersContext(t *testing.T) {
 	ctx := context.Background()
 
 	headers := map[string]string{
-		string(metahttp.UserID): "abcd",
+		string(models.UserID): "abcd",
 	}
 
 	err := metaHttpClient.Post(ctx, "/test", headers, req, &res)

--- a/pkg/meta_http/client_test.go
+++ b/pkg/meta_http/client_test.go
@@ -34,13 +34,14 @@ func TestMetaHTTPClient(t *testing.T) {
 	var res struct {
 		Goodbye string
 	}
-	err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
+	resp, err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	if res.Goodbye != "World" {
 		t.Error("Response body is not as expected")
 	}
+	t.Log(resp)
 }
 
 func TestTimeoutScenario(t *testing.T) {
@@ -63,10 +64,11 @@ func TestTimeoutScenario(t *testing.T) {
 	var res struct {
 		Goodbye string
 	}
-	err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
+	resp, err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
 	if err == nil {
 		t.Error("Supposed to fail with error")
 	}
+	t.Log(resp)
 }
 
 func TestContextHeaders(t *testing.T) {
@@ -94,13 +96,14 @@ func TestContextHeaders(t *testing.T) {
 	ctx = context.WithValue(ctx, models.UserID, "userId")
 	ctx = context.WithValue(ctx, models.RequestID, "request-id")
 
-	err := metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
+	resp, err := metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	if res[string(models.UserID)] != "userId" {
 		t.Error("Response body is not as expected")
 	}
+	t.Log(resp)
 }
 
 func TestHeadersContext(t *testing.T) {
@@ -131,20 +134,21 @@ func TestHeadersContext(t *testing.T) {
 		string(models.UserID): "abcd",
 	}
 
-	err := metaHttpClient.Post(ctx, "/test", headers, req, &res)
+	resp, err := metaHttpClient.Post(ctx, "/test", headers, req, &res)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	if res["data"] != "abcd" {
 		t.Error("Response body is not as expected")
 	}
-
+	t.Log(resp)
 	res = map[string]string{}
-	err = metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
+	resp, err = metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	if _, ok := res["data"]; ok {
 		t.Error("Data is not as expected")
 	}
+	t.Log(resp)
 }

--- a/pkg/meta_http/client_test.go
+++ b/pkg/meta_http/client_test.go
@@ -41,7 +41,7 @@ func TestMetaHTTPClient(t *testing.T) {
 	if res.Goodbye != "World" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp)
+	t.Log(resp.Status)
 }
 
 func TestTimeoutScenario(t *testing.T) {
@@ -68,7 +68,7 @@ func TestTimeoutScenario(t *testing.T) {
 	if err == nil {
 		t.Error("Supposed to fail with error")
 	}
-	t.Log(resp)
+	t.Log(resp.Status)
 }
 
 func TestContextHeaders(t *testing.T) {
@@ -103,7 +103,7 @@ func TestContextHeaders(t *testing.T) {
 	if res[string(models.UserID)] != "userId" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp)
+	t.Log(resp.Status)
 }
 
 func TestHeadersContext(t *testing.T) {
@@ -141,7 +141,7 @@ func TestHeadersContext(t *testing.T) {
 	if res["data"] != "abcd" {
 		t.Error("Response body is not as expected")
 	}
-	t.Log(resp)
+	t.Log(resp.Status)
 	res = map[string]string{}
 	resp, err = metaHttpClient.Post(ctx, "/test", map[string]string{}, req, &res)
 	if err != nil {
@@ -150,5 +150,34 @@ func TestHeadersContext(t *testing.T) {
 	if _, ok := res["data"]; ok {
 		t.Error("Data is not as expected")
 	}
-	t.Log(resp)
+	t.Log(resp.Status)
+}
+
+func TestMetaHTTPClient404(t *testing.T) {
+	responseBody := "{\"Goodbye\":\"World\"}"
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(responseBody))
+	}))
+	defer server.Close()
+
+	logger := log.NewJSONLogger(os.Stderr)
+	logger = log.NewSyncLogger(logger)
+
+	metaHttpClient := metahttp.NewClient("http://onmeta.in/hwiejwre", logger, 10*time.Second)
+	req := struct {
+		Hello string
+	}{
+		Hello: "world",
+	}
+	var res struct {
+		Goodbye string
+	}
+	resp, err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if res.Goodbye != "World" {
+		t.Error("Response body is not as expected")
+	}
+	t.Log(resp.Status)
 }

--- a/pkg/meta_http/client_test.go
+++ b/pkg/meta_http/client_test.go
@@ -152,32 +152,3 @@ func TestHeadersContext(t *testing.T) {
 	}
 	t.Log(resp.Status)
 }
-
-func TestMetaHTTPClient404(t *testing.T) {
-	responseBody := "{\"Goodbye\":\"World\"}"
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Write([]byte(responseBody))
-	}))
-	defer server.Close()
-
-	logger := log.NewJSONLogger(os.Stderr)
-	logger = log.NewSyncLogger(logger)
-
-	metaHttpClient := metahttp.NewClient("http://onmeta.in/hwiejwre", logger, 10*time.Second)
-	req := struct {
-		Hello string
-	}{
-		Hello: "world",
-	}
-	var res struct {
-		Goodbye string
-	}
-	resp, err := metaHttpClient.Post(context.Background(), "/test", map[string]string{}, req, &res)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	if res.Goodbye != "World" {
-		t.Error("Response body is not as expected")
-	}
-	t.Log(resp.Status)
-}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -1,5 +1,7 @@
 package models
 
+import "net/http"
+
 type contextKey string
 
 const (
@@ -12,3 +14,9 @@ const (
 )
 
 var ContextKeys = []contextKey{UserID, TenantID, RequestID, MerchantAPIKey, APIContextKey, AuthorizationKey}
+
+type ResponseData struct {
+	Status     string // e.g. "200 OK"
+	StatusCode int    // e.g. 200
+	Header     http.Header
+}


### PR DESCRIPTION
We need response object in full for web hook request to save in event table, hence returning the http response object from the http calls. 