### PR TITLE
capture html response for error case

### DIFF
--- a/pkg/meta_http/client.go
+++ b/pkg/meta_http/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -99,8 +100,9 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) (*models.Response
 			return nil, &errRes
 		}
 
+		body, _ := io.ReadAll(res.Body)
 		errRes.Err = ErrorInfo{
-			Message: fmt.Sprintf("unknown error, status code: %d", res.StatusCode),
+			Message: fmt.Sprintf("unknown error, status code: %d, response: %s", res.StatusCode, string(body)),
 		}
 		return nil, &errRes
 	}

--- a/pkg/meta_http/client.go
+++ b/pkg/meta_http/client.go
@@ -108,7 +108,6 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) (*models.Response
 	}
 
 	if err = json.NewDecoder(res.Body).Decode(&v); err != nil {
-		fmt.Println(err)
 		errRes := HttpClientErrorResponse{}
 		errRes.Success = false
 		errRes.StatusCode = http.StatusInternalServerError


### PR DESCRIPTION
capture html response body for error case, so that it can be captured at respective caller side.